### PR TITLE
Hide mobile button name in regulation config and update related logic

### DIFF
--- a/blocks/regulation-config/_regulation-config.json
+++ b/blocks/regulation-config/_regulation-config.json
@@ -40,7 +40,8 @@
           "name":"mobileButtonName",
           "label": "Text for Mobile button",
           "valueType": "string",
-          "value":"NAVIGATION"
+          "value":"NAVIGATION",
+          "hidden": true
         },
          {
           "component": "boolean",

--- a/blocks/regulation-config/regulation-config.js
+++ b/blocks/regulation-config/regulation-config.js
@@ -443,12 +443,15 @@ function decorateRegulationPage(menuToDisplay, mobileButtonTitle) {
 }
 
 export default async function decorate(doc) {
-  const [image, text, _mobileButtonTitle, ...booleans] = doc.children;
+  const [image, text, ...booleans] = doc.children;
 
   const menuOrden = ['about', 'how-to-apply', 'after-you-apply', 'operating-and-renewing'];
   const menuToDisplay = {};
 
-  const mobileButtonTitle = _mobileButtonTitle?.querySelector('p')?.innerText || 'NAVIGATION';
+  // const mobileButtonTitle = _mobileButtonTitle?.querySelector('p')?.innerText || 'NAVIGATION';
+  // going to be modify next
+
+  const mobileButtonTitle = 'NAVIGATION';
 
   booleans.forEach((d, idx) => {
     const el = d.querySelector('p');

--- a/blocks/regulation-tab-card/regulation-tab-card.js
+++ b/blocks/regulation-tab-card/regulation-tab-card.js
@@ -1,5 +1,21 @@
 import getContentFragment from '../../scripts/regulation-page-labels.js';
 
+function whatToShow() {
+  const r = {};
+  const listOfTabs = document.querySelectorAll('.menu-regulation-page ul li');
+
+  listOfTabs.forEach((li) => {
+    const tab = li.classList[1];
+    const isDisplay = !(li.style.display === 'none');
+
+    if (isDisplay) {
+      r[tab] = true;
+    }
+  });
+
+  return r;
+}
+
 export default function decorate(doc) {
   const data = (idx) => {
     const dataList = doc.children;
@@ -7,6 +23,8 @@ export default function decorate(doc) {
     const d = dataList[idx];
     return d;
   };
+
+  const visibleTabs = whatToShow();
 
   // - getValues
   const values = {
@@ -33,13 +51,13 @@ export default function decorate(doc) {
     'renewal-fees': {
       title: 'Renewal Fees:',
       link: {
-        text: 'Operating & Renewing', url: '/',
+        text: 'Operating and Renewing', url: '/',
       },
     },
     'renewal-cycle': {
       title: 'Renewal cycle:',
       link: {
-        text: 'Operating & Renewing',
+        text: 'Operating and Renewing',
         url: '/',
       },
     },
@@ -49,7 +67,14 @@ export default function decorate(doc) {
   const template = `
     <div class="tab-main-card">
       <div class="tab-main-card-card">
-      ${Object.keys(contentCard).map((key) => {
+      ${Object.keys(contentCard).filter((el) => {
+    const l = contentCard[el].link.text;
+    const property = l.toLowerCase().replace(/\s+/g, '-');
+    if (visibleTabs[property]) {
+      return true;
+    }
+    return false;
+  }).map((key) => {
     const KEY = contentCard[key];
 
     const { link } = KEY;

--- a/component-models.json
+++ b/component-models.json
@@ -1416,7 +1416,8 @@
         "name": "mobileButtonName",
         "label": "Text for Mobile button",
         "valueType": "string",
-        "value": "NAVIGATION"
+        "value": "NAVIGATION",
+        "hidden": true
       },
       {
         "component": "boolean",


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #feature-206434

Test URLs:
- Before: https://main--nyc-oti-eds-xwalk--bala-arumugam.aem.live/index/regulation-page
- After: https://feature-206434--nyc-oti-eds-xwalk--bala-arumugam.aem.live/index/regulation-page
